### PR TITLE
Feature: Support handling TLS certificate upload and making TLS requests

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -21,5 +21,14 @@ export interface Config {
         ttlInMinutes: number;
       };
     };
+    certStore?: {
+      /**
+       * @visibility frontend
+       */
+      enabled?: boolean;
+      provider?: string;
+      secretKey?: string;
+      initVector?: string;
+    }
   };
 }

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,16 @@
+// This file makes it possible to run "yarn knex migrate:make some_file_name"
+// to assist in making new migrations
+module.exports = {
+  client: 'postgresql',
+  connection: {
+    database: 'backstage_plugin_catalog',
+    host: 'localhost',
+    user: '',
+    port: 5432,
+    password: '',
+  },
+  useNullAsDefault: true,
+  migrations: {
+    directory: './migrations',
+  },
+};

--- a/migrations/20220802034031_init.js
+++ b/migrations/20220802034031_init.js
@@ -19,11 +19,7 @@ exports.up = async function (knex) {
           .timestamp('created_at', { useTz: false, precision: 0 })
           .notNullable()
           .defaultTo(knex.fn.now())
-          .comment('The creation time of the cert');
-
-        table
-          .timestamp('updated_at', { useTz: false, precision: 0 })
-          .comment('The update time of the cert');
+          .comment('The creation time of the cert')
           
         // table.string('root_cert_path');
         // table.string('root_cert_name');

--- a/migrations/20220802034031_init.js
+++ b/migrations/20220802034031_init.js
@@ -20,18 +20,6 @@ exports.up = async function (knex) {
           .notNullable()
           .defaultTo(knex.fn.now())
           .comment('The creation time of the cert')
-          
-        // table.string('root_cert_path');
-        // table.string('root_cert_name');
-        // table.text('root_cert_content').comment('Hashed root cert content');
-
-        // table.string('private_key_path');
-        // table.string('private_key_name');
-        // table.text('private_key_content').comment('Hashed private key content');
-
-        // table.string('cert_chain_path');
-        // table.string('cert_chain_name');
-        // table.text('cert_chain_content').comment('Hashed cert chain content');
 
         table.boolean('use_server_certificate').defaultTo(false);
       })

--- a/migrations/20220802034031_init.js
+++ b/migrations/20220802034031_init.js
@@ -1,0 +1,73 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  return (
+    knex.schema
+      .createTable('entity_certificates', table => {
+        table.comment('Entity certificates');
+        table
+          .uuid('id')
+          .primary()
+          .notNullable()
+          .comment('Auto-generated ID of the certificate');
+
+        table.string('entity_name').notNullable().comment('Entity name');
+
+        table
+          .timestamp('created_at', { useTz: false, precision: 0 })
+          .notNullable()
+          .defaultTo(knex.fn.now())
+          .comment('The creation time of the cert');
+
+        table
+          .timestamp('updated_at', { useTz: false, precision: 0 })
+          .comment('The update time of the cert');
+          
+        // table.string('root_cert_path');
+        // table.string('root_cert_name');
+        // table.text('root_cert_content').comment('Hashed root cert content');
+
+        // table.string('private_key_path');
+        // table.string('private_key_name');
+        // table.text('private_key_content').comment('Hashed private key content');
+
+        // table.string('cert_chain_path');
+        // table.string('cert_chain_name');
+        // table.text('cert_chain_content').comment('Hashed cert chain content');
+
+        table.boolean('use_server_certificate').defaultTo(false);
+      })
+      .createTable('certificate_files', table => {
+        table.uuid('certificate_id').notNullable();
+
+        table
+          .timestamp('created_at', { useTz: false, precision: 0 })
+          .notNullable()
+          .defaultTo(knex.fn.now())
+          .comment('The creation time of the cert');
+          
+        table.string('file_name').notNullable();
+        table.string('file_path');
+
+        table.enum('type', ['rootCert', 'privateKey', 'certChain']).notNullable().comment("Cert file type");
+
+        table.primary(['certificate_id', 'type']);
+
+        table.text('file_content').comment('Hashed file content');
+      })
+  );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  return (
+    knex.schema
+      .dropTableIfExists('entity_certificates')
+      .dropTableIfExists('certificate_files')
+  );
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-grpc-playground-backend",
-  "version": "0.1.4",
+  "version": "0.2.0-next.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "files": [
     "dist",
+    "migrations",
     "config.d.ts"
   ]
 }

--- a/src/api/sendRequest.ts
+++ b/src/api/sendRequest.ts
@@ -211,11 +211,6 @@ export class GRPCRequest extends EventEmitter {
       }
       if (this.tlsCertificate.useServerCertificate === true) {
         creds = credentials.createSsl();
-        // creds = credentials.createSsl(
-        //   fs.readFileSync('/Users/thaotx/Desktop/node-grpc-ssl/certs/ca.crt'),
-        //   fs.readFileSync('/Users/thaotx/Desktop/node-grpc-ssl/certs/client.key'),
-        //   fs.readFileSync('/Users/thaotx/Desktop/node-grpc-ssl/certs/client.crt'),
-        // );
       } else {
         try {
           creds = credentials.createSsl(

--- a/src/api/sendRequest.ts
+++ b/src/api/sendRequest.ts
@@ -210,6 +210,11 @@ export class GRPCRequest extends EventEmitter {
       }
       if (this.tlsCertificate.useServerCertificate === true) {
         creds = credentials.createSsl();
+        // creds = credentials.createSsl(
+        //   fs.readFileSync('/Users/thaotx/Desktop/node-grpc-ssl/certs/ca.crt'),
+        //   fs.readFileSync('/Users/thaotx/Desktop/node-grpc-ssl/certs/client.key'),
+        //   fs.readFileSync('/Users/thaotx/Desktop/node-grpc-ssl/certs/client.crt'),
+        // );
       } else {
         creds = credentials.createSsl(
           fs.readFileSync(this.tlsCertificate.rootCert.filePath),

--- a/src/api/sendRequest.ts
+++ b/src/api/sendRequest.ts
@@ -197,6 +197,7 @@ export class GRPCRequest extends EventEmitter {
    * @param ServiceClient
    */
   private getClient(ServiceClient: ServiceClientConstructor): ServiceClient {
+    const logger = getLogger();
     let creds = credentials.createInsecure();
     let options = {};
 
@@ -216,11 +217,21 @@ export class GRPCRequest extends EventEmitter {
         //   fs.readFileSync('/Users/thaotx/Desktop/node-grpc-ssl/certs/client.crt'),
         // );
       } else {
-        creds = credentials.createSsl(
-          fs.readFileSync(this.tlsCertificate.rootCert.filePath),
-          this.tlsCertificate.privateKey && fs.readFileSync(this.tlsCertificate.privateKey.filePath),
-          this.tlsCertificate.certChain && fs.readFileSync(this.tlsCertificate.certChain.filePath),
-        );
+        try {
+          creds = credentials.createSsl(
+            fs.readFileSync(this.tlsCertificate.rootCert.filePath),
+            this.tlsCertificate.privateKey && fs.readFileSync(this.tlsCertificate.privateKey.filePath),
+            this.tlsCertificate.certChain && fs.readFileSync(this.tlsCertificate.certChain.filePath),
+          );
+        } catch (err) {
+          logger.error(`Error reading tls certificate: ${err}`);
+
+          this.emit(GRPCEventType.ERROR, {
+            details: err.message,
+          }, {});
+
+          this.emit(GRPCEventType.END);
+        }
       }
     }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,6 +1,7 @@
 import { LoadCertStatus, LoadProtoStatus } from "../service/utils";
 
 export interface Certificate {
+  id?: string;
   rootCert: CertFile;
   privateKey?: CertFile;
   certChain?: CertFile;
@@ -17,6 +18,7 @@ export type CertType = 'rootCert' | 'privateKey' | 'certChain';
 
 export interface CertFile extends BaseFile {
   type: CertType;
+  content?: string;
 }
 
 export interface FileWithImports extends BaseFile {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,3 +1,5 @@
+import { LoadCertStatus, LoadProtoStatus } from "../service/utils";
+
 export interface Certificate {
   rootCert: CertFile;
   privateKey?: CertFile;
@@ -11,7 +13,11 @@ export interface BaseFile {
   filePath: string;
 }
 
-export interface CertFile extends BaseFile {}
+export type CertType = 'rootCert' | 'privateKey' | 'certChain';
+
+export interface CertFile extends BaseFile {
+  type: CertType;
+}
 
 export interface FileWithImports extends BaseFile {
   imports?: PlaceholderFile[];
@@ -45,3 +51,11 @@ export interface EntitySpec extends BaseEntitySpec {
   files: PlaceholderFile[];
   imports?: PlaceholderFile[];
 }
+
+export type LoadCertResult = {
+  certs?: CertFile[];
+  status?: LoadCertStatus;
+  missingCerts?: Partial<CertFile>[];
+  message?: string;
+  certificate?: Certificate;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './service/router';
+export * from './service/CertStore';

--- a/src/service/CertStore/CertStore.ts
+++ b/src/service/CertStore/CertStore.ts
@@ -1,0 +1,50 @@
+import { PluginDatabaseManager } from "@backstage/backend-common";
+import { Config } from "@backstage/config";
+import { Logger } from "winston";
+import { DatabaseCertStore } from "./DatabaseCertStore";
+import { MemoryCertStore } from "./MemoryStore";
+import { CertStore } from "./types";
+
+interface Options {
+  logger: Logger;
+  database: PluginDatabaseManager;
+}
+
+export class CertStores {
+  static async fromConfig(
+    config: Config,
+    options: Options
+  ): Promise<CertStore | undefined> {
+    const { database } = options;
+    const certStore = config.getOptionalConfig('grpcPlayground.certStore');
+
+    if (!certStore || !certStore.getOptionalBoolean('enabled')) {
+      return undefined;
+    }
+
+    const provider = certStore.getOptionalString('provider') ?? 'database';
+    const secretKey = certStore.getOptionalString('secretKey') ?? 'qwertyuiopasdfghjklzxcvbnm123456'; // 32 chars
+    const initVector = certStore.getOptionalString('initVector') ?? '1234567890123456'; // 16 chars
+
+    if (provider === 'database') {
+      if (!database) {
+        throw new Error('This CertStore provider requires a database');
+      }
+
+      return await DatabaseCertStore.create({
+        database: await database.getClient(),
+        secretKey,
+        initVector,
+      });
+    }
+
+    if (provider === 'memory') {
+      return new MemoryCertStore({
+        secretKey,
+        initVector,
+      });
+    }
+
+    throw new Error(`Unknown cert store provider: ${provider}`);
+  }
+}

--- a/src/service/CertStore/DatabaseCertStore.ts
+++ b/src/service/CertStore/DatabaseCertStore.ts
@@ -46,7 +46,6 @@ const TABLE_CERTIFICATE_FILES = 'certificate_files';
 type CertificateRow = {
   id: string;
   created_at: Date;
-  updated_at: Date;
   entity_name: string;
   use_server_certificate: boolean;
 }
@@ -202,10 +201,6 @@ export class DatabaseCertStore implements CertStore {
       })
       .onConflict(['certificate_id', 'type'])
       .merge(['file_content', 'file_name', 'file_path']);
-
-    await this.database<CertificateRow>(TABLE_CERTIFICATES)
-      .where('id', id)
-      .update('updated_at', now);
   }
 
   async deleteCertificate(id: string): Promise<void> {

--- a/src/service/CertStore/DatabaseCertStore.ts
+++ b/src/service/CertStore/DatabaseCertStore.ts
@@ -1,0 +1,251 @@
+import { resolve as resolvePath } from 'path';
+import { Knex } from 'knex';
+import { v4 as uuid } from 'uuid';
+import { resolvePackagePath } from '@backstage/backend-common';
+
+import { CertStore, Encoder } from './types';
+import { DefaultEncoder } from './encrypt';
+
+import { CertFile, Certificate, CertType } from '../../api';
+
+type Options = {
+  database: Knex;
+  secretKey: string;
+  initVector: string;
+}
+
+
+
+let migrationsDir: string;
+
+try {
+  migrationsDir = resolvePackagePath(
+    'backstage-grpc-playground-backend',
+    'migrations'
+  );
+} catch (err) {
+  // Manual resolve package path, works on dev when linking packages
+  function manualResolvePackagePath(name: string, ...paths: string[]) {
+    const req =
+      typeof __non_webpack_require__ === 'undefined'
+        ? require
+        : __non_webpack_require__;
+  
+    return resolvePath(req.resolve(`${name}/package.json`), '..', ...paths);
+  }
+  
+  migrationsDir = manualResolvePackagePath(
+    'backstage-grpc-playground-backend',
+    'migrations'
+  );
+}
+
+const TABLE_CERTIFICATES = 'entity_certificates';
+const TABLE_CERTIFICATE_FILES = 'certificate_files';
+
+type CertificateRow = {
+  id: string;
+  created_at: Date;
+  updated_at: Date;
+  entity_name: string;
+  use_server_certificate: boolean;
+}
+
+type CertificateFileRow = {
+  certificate_id: string;
+  created_at: Date;
+  file_content?: string;
+  file_path?: string;
+  file_name: string;
+  type: CertType;
+}
+
+export class DatabaseCertStore implements CertStore {
+  private database: Knex;
+  private encoder: Encoder;
+
+  private constructor(options: Options) {
+    this.database = options.database;
+    this.encoder = DefaultEncoder.fromConfig(options);
+  }
+
+  static async create(options: Options) {
+    const { database } = options;
+
+    await database.migrate.latest({
+      directory: migrationsDir,
+    });
+
+    return new DatabaseCertStore(options);
+  }
+
+  private async toDBCertFile(cert: CertFile) {
+    const { fileName, content, filePath, type } = cert;
+
+    const result: Partial<CertificateFileRow> = {
+      file_name: fileName,
+      file_path: filePath,
+      type,
+    };
+
+    if (content) {
+      const encodedContent = this.encoder.encode(content);
+
+      result.file_content = encodedContent;
+    }
+
+    return result;
+  }
+
+  private async insertCertFile(certificateId: string, cert: CertFile) {
+    const insertObj: Partial<CertificateFileRow> = {
+      certificate_id: certificateId,
+      ...await this.toDBCertFile(cert),
+      created_at: new Date(),
+    };
+
+    return this.database<CertificateFileRow>(TABLE_CERTIFICATE_FILES)
+      .insert(insertObj);
+  }
+
+  async getCertificate(id: string): Promise<Certificate | undefined> {
+    const certFilesWithCertificateId = await this.database<CertificateRow>(TABLE_CERTIFICATES)
+      .where('id', id)
+      .select('id')
+      .innerJoin<CertificateFileRow>(TABLE_CERTIFICATE_FILES, {
+        [`${TABLE_CERTIFICATES}.id`]: `${TABLE_CERTIFICATE_FILES}.certificate_id`,
+      })
+      .select('file_name', 'file_path', 'type');
+
+    const dictById = certFilesWithCertificateId.reduce((dict, { id, file_name, type, file_path }) => {
+      if (!dict[id]) {
+        dict[id] = {} as Certificate;
+      }
+
+      dict[id][type] = {
+        fileName: file_name,
+        filePath: file_path,
+        type,
+      } as CertFile;
+
+      return dict;
+    }, {} as Record<string, Certificate>);
+
+    return dictById[id];
+  }
+
+  async getCertFile(id: string, certType: CertType): Promise<CertFile | undefined> {
+    const certificate = await this.database<CertificateFileRow>(TABLE_CERTIFICATE_FILES)
+      .where('certificate_id', id)
+      .andWhere('type', certType)
+      .select('*')
+      .first();
+
+    if (!certificate) {
+      return undefined;
+    }
+
+    const { file_name: fileName, file_content: content, file_path: filePath = '', type } = certificate;
+
+    return {
+      type,
+      fileName,
+      filePath,
+      content: content ? this.encoder.decode(content) : undefined,
+    }
+  }
+
+  async insertCertificateIfNeeded(entityName: string, rootCert: CertFile): Promise<string> {
+    const existingCertificate = await this.database<CertificateRow>(TABLE_CERTIFICATES)
+      .where('entity_name', entityName)
+      .select('id')
+      .innerJoin<CertificateFileRow>(TABLE_CERTIFICATE_FILES, {
+        [`${TABLE_CERTIFICATES}.id`]: `${TABLE_CERTIFICATE_FILES}.certificate_id`,
+      })
+      .where('file_path', rootCert.filePath)
+      .first();
+
+    if (existingCertificate) {
+      await this.updateCertificate(existingCertificate.id, rootCert);
+
+      return existingCertificate.id;
+    }
+
+    const id = uuid();
+    const creationTime = new Date();
+
+    await this.database<CertificateRow>(TABLE_CERTIFICATES)
+      .insert({
+        id,
+        entity_name: entityName,
+        created_at: creationTime,
+      });
+
+    await this.insertCertFile(id, rootCert);
+
+    return id;
+  }
+
+  async updateCertificate(id: string, cert: CertFile): Promise<void> {
+    const now = new Date();
+    const newCert: Partial<CertificateFileRow> = {
+      certificate_id: id,
+      ...await this.toDBCertFile(cert),
+    };
+
+    // If the cert file is already present, update it
+    // "upsert" action with knex
+    await this.database<CertificateFileRow>(TABLE_CERTIFICATE_FILES)
+      .insert({
+        ...newCert,
+        created_at: now,
+      })
+      .onConflict(['certificate_id', 'type'])
+      .merge(['file_content', 'file_name', 'file_path']);
+
+    await this.database<CertificateRow>(TABLE_CERTIFICATES)
+      .where('id', id)
+      .update('updated_at', now);
+  }
+
+  async deleteCertificate(id: string): Promise<void> {
+    const deleted = await this.database<CertificateRow>(TABLE_CERTIFICATES)
+      .where('id', id)
+      .delete();
+
+    if (deleted) {
+      await this.database<CertificateFileRow>(TABLE_CERTIFICATE_FILES)
+        .where('certificate_id', id)
+        .delete();
+    }
+  }
+
+  async listCertificates(entityName: string): Promise<Certificate[]> {
+    const certFilesWithCertificateId = await this.database<CertificateRow>(TABLE_CERTIFICATES)
+      .where('entity_name', entityName)
+      .select('id')
+      .innerJoin<CertificateFileRow>(TABLE_CERTIFICATE_FILES, {
+        [`${TABLE_CERTIFICATES}.id`]: `${TABLE_CERTIFICATE_FILES}.certificate_id`,
+      })
+      .select('file_name', 'file_path', 'type');
+
+    const dictById = certFilesWithCertificateId.reduce((dict, { id, file_name, type, file_path }) => {
+      if (!dict[id]) {
+        dict[id] = {} as Certificate;
+      }
+
+      dict[id][type] = {
+        fileName: file_name,
+        filePath: file_path,
+        type,
+      } as CertFile;
+
+      return dict;
+    }, {} as Record<string, Certificate>);
+
+    return Object.keys(dictById).map((id: string): Certificate => ({
+      id,
+      ...dictById[id],
+    }));
+  }
+}

--- a/src/service/CertStore/MemoryStore.ts
+++ b/src/service/CertStore/MemoryStore.ts
@@ -6,7 +6,6 @@ import { pick } from "lodash";
 
 type CertificateRow = Certificate & {
   createdAt: Date;
-  updatedAt?: Date;
   entityName: string;
 }
 
@@ -57,7 +56,6 @@ export class MemoryCertStore implements CertStore {
       };
 
       certificate[cert.type] = newCertFile;
-      certificate.updatedAt = now;
     }
   }
 

--- a/src/service/CertStore/MemoryStore.ts
+++ b/src/service/CertStore/MemoryStore.ts
@@ -1,0 +1,164 @@
+import { CertFile, Certificate, CertType } from "../../api";
+import { CertStore, Encoder } from "./types";
+import { v4 as uuid } from 'uuid';
+import { DefaultEncoder } from "./encrypt";
+import { pick } from "lodash";
+
+type CertificateRow = Certificate & {
+  createdAt: Date;
+  updatedAt?: Date;
+  entityName: string;
+}
+
+type CertificateFileRow = CertFile & {
+  certificateId: string;
+  createdAt: Date;
+}
+
+type Options = {
+  secretKey: string;
+  initVector: string;
+}
+
+export class MemoryCertStore implements CertStore {
+  private readonly encoder: Encoder;
+
+  // Databases
+  private readonly certificatesById: { [id: string]: CertificateRow } = {};
+  private readonly certificatesByEntity: { [entityName: string]: string[] } = {};
+
+  constructor(options: Options) {
+    this.encoder = DefaultEncoder.fromConfig(options);
+  }
+
+  async insertCertificateIfNeeded(entityName: string, rootCert: CertFile): Promise<string> {
+    const entityCertificates = this.getEntityCertificates(entityName)
+
+    const existingCertificate = entityCertificates.find(cert => cert.rootCert.filePath === rootCert.filePath);
+
+    if (existingCertificate?.id) {
+      this.updateCertificate(existingCertificate.id, rootCert);
+
+      return existingCertificate.id;
+    }
+
+    return this.insertCertificate(entityName, rootCert);
+  }
+
+  async updateCertificate(id: string, cert: CertFile): Promise<void> {
+    const certificate = this.certificatesById[id];
+
+    if (certificate) {
+      const now = new Date();
+      const newCertFile: CertificateFileRow = {
+        ...this.toDBCertFile(cert),
+        certificateId: id,
+        createdAt: now,
+      };
+
+      certificate[cert.type] = newCertFile;
+      certificate.updatedAt = now;
+    }
+  }
+
+  async deleteCertificate(id: string): Promise<void> {
+    delete this.certificatesById[id];
+
+    for (const entityCerts of Object.keys(this.certificatesByEntity)) {
+      if (this.certificatesByEntity[entityCerts].includes(id)) {
+        this.certificatesByEntity[entityCerts] = this.certificatesByEntity[entityCerts].filter(certId => certId !== id);
+      }
+    }
+  }
+
+  async listCertificates(entityName: string): Promise<Certificate[]> {
+    return this.getEntityCertificates(entityName).map(this.toDTO.bind(this));
+  }
+
+  async getCertificate(id: string): Promise<Certificate | undefined> {
+    return this.certificatesById[id] ? this.toDTO(this.certificatesById[id]) : undefined;
+  }
+
+  async getCertFile(id: string, certType: CertType): Promise<CertFile | undefined> {
+    const certificate = this.certificatesById[id];
+
+    if (!certificate) return undefined;
+
+    const certFile = certificate[certType];
+
+    return certFile ? {
+      ...certFile,
+      content: certFile.content ? this.encoder.decode(certFile.content) : undefined,
+    } : undefined;
+  }
+
+  //
+  // HELPERS
+  //
+  private initEntityCertificatesIfNeeded(entityName: string): void {
+    this.certificatesByEntity[entityName] = this.certificatesByEntity[entityName] || [];
+  }
+
+  private getEntityCertificates(entityName: string): CertificateRow[] {
+    this.initEntityCertificatesIfNeeded(entityName);
+    const certificateIdsByEntity = this.certificatesByEntity[entityName];
+
+    return certificateIdsByEntity.map(id => this.certificatesById[id]);
+  }
+
+  private insertCertificate(entityName: string, pRootCert: CertFile): string {
+    const now = new Date();
+    const certificateId = uuid();
+
+    const rootCert: CertificateFileRow = {
+      ...this.toDBCertFile(pRootCert),
+      certificateId,
+      createdAt: now,
+    }
+
+    const certificate: CertificateRow = {
+      id: certificateId,
+      createdAt: now,
+      entityName,
+      rootCert,
+    }
+
+    this.certificatesById[certificateId] = certificate;
+    this.initEntityCertificatesIfNeeded(certificate.entityName);
+    this.certificatesByEntity[certificate.entityName].push(certificateId);
+
+    return certificateId;
+  }
+
+  private toDBCertFile(cert: CertFile) {
+    const { fileName, content, filePath, type } = cert;
+
+    const result: CertFile = {
+      fileName,
+      filePath,
+      type,
+    };
+
+    if (content) {
+      const encodedContent = this.encoder.encode(content);
+      result.content = encodedContent;
+    }
+
+    return result;
+  }
+
+  private toDTO(certificate: CertificateRow): Certificate {
+    return {
+      id: certificate.id,
+      rootCert: this.toDTOCertFile(certificate.rootCert),
+      privateKey: certificate.privateKey ? this.toDTOCertFile(certificate.privateKey) : undefined,
+      certChain: certificate.certChain ? this.toDTOCertFile(certificate.certChain) : undefined,
+      useServerCertificate: certificate.useServerCertificate,
+      sslTargetHost: certificate.sslTargetHost,
+    }
+  }
+
+  private toDTOCertFile(certFile: CertFile): CertFile {
+    return pick(certFile, 'fileName', 'filePath', 'type');
+  }
+}

--- a/src/service/CertStore/encrypt.ts
+++ b/src/service/CertStore/encrypt.ts
@@ -1,0 +1,54 @@
+import crypto from 'crypto';
+import { Encoder } from "./types";
+
+type Options = {
+  secretKey: string; // 32 length string
+  initVector: string; // 16 length string
+}
+
+export class DefaultEncoder implements Encoder {
+  private readonly algorithm = "aes-256-cbc";
+  private readonly secretKey: Buffer;
+  private readonly initVector: Buffer;
+
+  private constructor(
+    secretKey: string,
+    initVector: string
+  ) {
+    if (secretKey.length !== 32) {
+      throw new Error('Secret key must be 32 length string');
+    }
+
+    if (initVector.length !== 16) {
+      throw new Error('Init vector must be 16 length string');
+    }
+
+    this.secretKey = Buffer.from(secretKey);
+    this.initVector = Buffer.from(initVector);
+  }
+
+  static fromConfig(options: Options) {
+    const { secretKey, initVector } = options;
+    return new DefaultEncoder(secretKey, initVector);
+  }
+
+  encode(data: string): string {
+    const cipher = crypto.createCipheriv(this.algorithm, this.secretKey, this.initVector);
+
+    // encrypt the message
+    let encryptedData = cipher.update(data, "utf-8", "hex");
+    encryptedData += cipher.final("hex");
+
+    return encryptedData;
+  }
+
+  decode(encoded: string) {
+    const decipher = crypto.createDecipheriv(this.algorithm, this.secretKey, this.initVector);
+
+    // decrypt the message
+    let decryptedData = decipher.update(encoded, "hex", "utf-8");
+    decryptedData += decipher.final("utf8");
+
+    return decryptedData;
+  }
+}

--- a/src/service/CertStore/index.ts
+++ b/src/service/CertStore/index.ts
@@ -1,0 +1,2 @@
+export { CertStores } from './CertStore';
+export * from './types';

--- a/src/service/CertStore/types.ts
+++ b/src/service/CertStore/types.ts
@@ -1,0 +1,15 @@
+import { CertFile, Certificate, CertType } from "../../api";
+
+export interface CertStore {
+  insertCertificateIfNeeded(entityName: string, rootCert: CertFile): Promise<string>;
+  updateCertificate(id: string, cert: CertFile): Promise<void>;
+  deleteCertificate(id: string): Promise<void>;
+  listCertificates(entityName: string): Promise<Certificate[]>;
+  getCertificate(id: string): Promise<Certificate | undefined>;
+  getCertFile(id: string, certType: CertType): Promise<CertFile | undefined>;
+}
+
+export interface Encoder {
+  encode(data: string): string;
+  decode(encoded: string): string;
+}

--- a/src/service/router.test.ts
+++ b/src/service/router.test.ts
@@ -14,13 +14,27 @@
  * limitations under the License.
  */
 
-import { getVoidLogger, UrlReader } from '@backstage/backend-common';
+import { DatabaseManager, getVoidLogger, PluginDatabaseManager, UrlReader } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { PlaceholderResolverRead } from '@backstage/plugin-catalog-backend';
 import express from 'express';
 import request from 'supertest';
 
 import { createRouter } from './router';
+
+function createDatabase(): PluginDatabaseManager {
+  return DatabaseManager.fromConfig(
+    new ConfigReader({
+      backend: {
+        database: {
+          client: 'better-sqlite3',
+          connection: ':memory:',
+        },
+      },
+    }),
+  ).forPlugin('backstage-grpc-playground-backend');
+}
 
 describe('createRouter', () => {
   let app: express.Express;
@@ -32,6 +46,7 @@ describe('createRouter', () => {
     const router = await createRouter({
       logger: getVoidLogger(),
       reader,
+      database: createDatabase(),
       integrations: {} as unknown as ScmIntegrationRegistry,
     });
 

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -310,13 +310,6 @@ export async function createRouter(
 
       filename: function (_req, file, callback) {
         const fileName = file.originalname;
-
-        // handle duplication
-        // if (fs.existsSync(resolveRelativePath(file.originalname))) {
-        //   const { ext, name } = path.parse(file.originalname);
-        //   fileName = `${name}-${timestamp()}${ext}`;
-        // }
-
         callback(null, fileName);
       },
     });
@@ -421,13 +414,6 @@ export async function createRouter(
 
       filename: function (_req, file, callback) {
         const fileName = file.originalname;
-
-        // handle duplication
-        // if (fs.existsSync(resolveRelativePath(file.originalname))) {
-        //   const { ext, name } = path.parse(file.originalname);
-        //   fileName = `${name}-${timestamp()}${ext}`;
-        // }
-
         callback(null, fileName);
       },
     });

--- a/src/service/utils.ts
+++ b/src/service/utils.ts
@@ -27,6 +27,12 @@ export enum LoadProtoStatus {
   part = 0,
 }
 
+export enum LoadCertStatus {
+  ok = 3,
+  fail = 4,
+  part = 5
+}
+
 export function getFileNameFromPath(p: string) {
   return path.basename(p);
 }
@@ -116,6 +122,12 @@ export const placeholderFile = (() => {
   });
 })();
 
+const certFile = z.object({
+  fileName: z.string(),
+  filePath: z.string(),
+  type: z.enum(['rootCert', 'privateKey', 'certChain']),
+});
+
 export const sendRequestInput = z
   .object({
     requestId: z.string(),
@@ -126,6 +138,13 @@ export const sendRequestInput = z
         stream: z.any(),
       })
       .required(),
+    tlsCertificate: z.object({
+      useServerCertificate: z.boolean().optional(),
+      rootCert: certFile,
+      privateKey: certFile.optional(),
+      certChain: certFile.optional(), 
+      sslTargetHost: z.string().optional(),
+    }).optional(),
     proto: z.string(),
     methodName: z.string(),
     serviceName: z.string(),

--- a/src/service/utils.ts
+++ b/src/service/utils.ts
@@ -139,6 +139,7 @@ export const sendRequestInput = z
       })
       .required(),
     tlsCertificate: z.object({
+      id: z.string().optional(),
       useServerCertificate: z.boolean().optional(),
       rootCert: certFile,
       privateKey: certFile.optional(),


### PR DESCRIPTION
need https://github.com/zalopay-oss/backstage-grpc-playground/pull/8 to resolves https://github.com/zalopay-oss/backstage-grpc-playground/issues/1

- developer can choose to store certificate files with encoded content
to memory or database for recovery purpose
  - for secretKey and initVector: I suggest generate one at
[http://www.unit-conversion.info/texttools/random-string-generator/](http://www.unit-conversion.info/texttools/random-string-generator/)
for 32-char and 16-char strings with allowedChars:
`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789=-+/`
- if for any reason that some files of a certificate are missing, we will
return an array "missingCerts" for client to process