### PR TITLE
fix: update removed 'read' calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.15.0",
+    "@backstage/backend-common": "^0.19.0",
     "@backstage/config": "^1.0.1",
     "@backstage/errors": "^1.1.0",
     "@backstage/integration": "^1.3.0",

--- a/src/api/placeholderProcessor.ts
+++ b/src/api/placeholderProcessor.ts
@@ -44,12 +44,9 @@ export class CustomPlaceholderProcessor {
     logger.info(`OUTPUT ~ CustomPlaceholderProcessor ~ libraries: ${libraries}`);
 
     const read = async (url: string): Promise<Buffer> => {
-      if (this.options.reader.readUrl) {
-        const response = await this.options.reader.readUrl(url);
-        const buffer = await response.buffer();
-        return buffer;
-      }
-      return this.options.reader.read(url);
+      const response = await this.options.reader.readUrl(url);
+      const buffer = await response.buffer();
+      return buffer;
     };
 
     const readLibrary = async (lib: Library) => {

--- a/src/service/router.test.ts
+++ b/src/service/router.test.ts
@@ -17,7 +17,6 @@
 import { DatabaseManager, getVoidLogger, PluginDatabaseManager, UrlReader } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { ScmIntegrationRegistry } from '@backstage/integration';
-import { PlaceholderResolverRead } from '@backstage/plugin-catalog-backend';
 import express from 'express';
 import request from 'supertest';
 
@@ -40,8 +39,7 @@ describe('createRouter', () => {
   let app: express.Express;
 
   beforeAll(async () => {
-    const read: jest.MockedFunction<PlaceholderResolverRead> = jest.fn();
-    const reader: UrlReader = { read, readTree: jest.fn(), search: jest.fn() };
+    const reader: jest.Mocked<UrlReader> = { readUrl: jest.fn(), readTree: jest.fn(), search: jest.fn() };
 
     const router = await createRouter({
       logger: getVoidLogger(),


### PR DESCRIPTION
A [Backstage PR][1] removed the `read` call from the UrlReaderService implementation, which causes this backend plugin to no longer build properly.

The changes here mirror what is presented within the backstage PR for implementation adjustments.

[1]: https://github.com/backstage/backstage/pull/13820